### PR TITLE
Add function to compute atom indices for boxes

### DIFF
--- a/bomeba0/OBB.py
+++ b/bomeba0/OBB.py
@@ -1,5 +1,5 @@
 """
-sdfkjhh<ssdjfhsjkdhf
+Write me! 
 """
 from .residues import aa_templates
 

--- a/bomeba0/OBB.py
+++ b/bomeba0/OBB.py
@@ -1,0 +1,55 @@
+"""
+sdfkjhh<ssdjfhsjkdhf
+"""
+from .residues import aa_templates
+
+def _little_boxes(prot):
+        """
+        Returns a list of lists, each list contains the indices of atoms
+        belonging to a different box. These indices will then be used to
+        retrieve the coordinates for the atoms in each box.
+        See 10.1145/237170.237244 for details.
+
+        Parameters
+        ----------
+        prot : protein object
+        
+        Returns
+        ----------
+        boxes : list
+        """
+        offsets = prot._offsets     
+        
+        boxes = []
+        seq = prot.sequence
+        lenght = len(seq) - 1
+        for resnum, resname in enumerate(seq):
+            resinfo = aa_templates[resname]
+            offset_0 = offsets[resnum - 1]
+            offset_1 = offsets[resnum]
+
+            idx_ca = [_ + offset_1 for _ in resinfo.sc]
+            idx_ca += [resinfo.atom_names.index('CA') + offset_1]
+            idx_ca += [resinfo.atom_names.index('HA') + offset_1] 
+    
+            idx_p = [resinfo.atom_names.index('C') + offset_0]
+            idx_p += [resinfo.atom_names.index('O') + offset_0]
+            idx_p += [resinfo.atom_names.index('N') + offset_1] 
+            idx_p += [resinfo.atom_names.index('H') + offset_1]
+
+            if  0 < resnum < lenght: 
+                boxes.append(idx_p)
+                boxes.append(idx_ca)
+            else:
+                if resnum == 0:
+                    idx_n = [resinfo.atom_names.index('N') + offset_1] 
+                    idx_n += [resinfo.atom_names.index('H') + offset_1]
+                    boxes.append(idx_n)
+                    boxes.append(idx_ca)
+                elif resnum == lenght:
+                    boxes.append(idx_p)
+                    boxes.append(idx_ca)
+                    idx_c = [resinfo.atom_names.index('C') + offset_1]
+                    idx_c += [resinfo.atom_names.index('O') + offset_1]
+                    boxes.append(idx_c)
+        return boxes

--- a/bomeba0/__init__.py
+++ b/bomeba0/__init__.py
@@ -1,2 +1,3 @@
 from .biomolecules import *
+from .OBB import *
 from .plots import *

--- a/bomeba0/tests/test_OBB.py
+++ b/bomeba0/tests/test_OBB.py
@@ -1,0 +1,23 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
+from ..biomolecules import Protein
+from ..OBB import _little_boxes
+
+seq_reference = 'AAA'
+prot = Protein(seq_reference)
+
+
+def test_little_boxes():
+    l = np.vstack((prot.at_coords(0, 'N'), prot.at_coords(0, 'H')))
+    m = np.vstack((prot.at_coords(0, 'sc'), prot.at_coords(0, 'CA'), prot.at_coords(0, 'HA')))
+    n = np.vstack((prot.at_coords(0, 'C'), prot.at_coords(0, 'O'), prot.at_coords(1, 'N'), prot.at_coords(1, 'H')))
+    o = np.vstack((prot.at_coords(1, 'sc'), prot.at_coords(1, 'CA'), prot.at_coords(1, 'HA')))
+    p = np.vstack((prot.at_coords(1, 'C'), prot.at_coords(1, 'O'), prot.at_coords(2, 'N'), prot.at_coords(2, 'H')))
+    q = np.vstack((prot.at_coords(2, 'sc'), prot.at_coords(2, 'CA'), prot.at_coords(2, 'HA')))
+    r = np.vstack((prot.at_coords(2, 'C'), prot.at_coords(2, 'O')))
+    sel_0 = [l, m, n, o, p, q, r]
+    boxes = _little_boxes(prot)
+    xyz = prot.coords
+    sel_1 = [xyz.take(i, 0) for i in  boxes]
+    for i,j in zip(sel_0, sel_1):
+        assert_almost_equal(i, j)


### PR DESCRIPTION
The indices are computed only once and then used to extract the coordinates. 

```python
xyz = prot.coords
boxes = bmb.OBB._little_boxes(prot)
selec =  [xyz.take(i) for i in  boxes]
```


This is ~8 times faster than using  ```at_coords```.