### PR TITLE
Initiliaze a protein object also from a pdb file

### DIFF
--- a/bomeba0/residues.py
+++ b/bomeba0/residues.py
@@ -501,3 +501,9 @@ one_to_three = {'A': 'ALA', 'C': 'CYS', 'D': 'ASP', 'E': 'GLU', 'F': 'PHE',
                 'G': 'GLY', 'H': 'HIS', 'I': 'ILE', 'K': 'LYS', 'L': 'LEU',
                 'M': 'MET', 'N': 'ASN', 'P': 'PRO', 'Q': 'GLN', 'R': 'ARG',
                 'S': 'SER', 'T': 'THR', 'V': 'VAL', 'W': 'TRP', 'Y': 'TYR'}
+                
+three_to_one = {'ALA': 'A', 'ARG': 'R', 'ASN': 'N', 'ASP': 'D', 'CYS': 'C',
+                'GLN': 'Q', 'GLU': 'E', 'GLY': 'G', 'HIS': 'H', 'ILE': 'I',
+                'LEU': 'L', 'LYS': 'K', 'MET': 'M', 'PHE': 'F', 'PRO': 'P',
+                'SER': 'S', 'THR': 'T', 'TRP': 'W', 'TYR': 'Y', 'VAL': 'V'}
+

--- a/bomeba0/tests/test_protein.py
+++ b/bomeba0/tests/test_protein.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
+import filecmp
 from ..biomolecules import Protein
 
 seq_reference = 'GG'
@@ -70,4 +71,11 @@ def test_at_coords():
     assert_almost_equal(prot.at_coords(1), prot.coords[7:])
     assert_almost_equal(prot.at_coords(1, 'N'), prot.coords[7])
     assert_almost_equal(prot.at_coords(1, 'bb'), prot.coords[7:])
-    assert len(prot.at_coords(1, 'sc')) == 0 
+    assert len(prot.at_coords(1, 'sc')) == 0
+    
+def test_protein():
+    prot.dump_pdb('test_1')
+    prot2 = Protein(pdb='test_1.pdb')
+    prot2.dump_pdb('test_2')
+    assert filecmp.cmp('test_1.pdb', 'test_2.pdb')
+    


### PR DESCRIPTION
Now a protein can be initialized from a sequence or from a pdb file. For the moment only works with _nice_ pdb file read protein docstring for details.

Things to do in the near future (¿next week?)

* refactor `_prot_builder_from_seq` and  `_prot_builder_from_seq` (both share common code)
* handle more complex pdb files.
* add option to _regularize_, that is to use the torsional angles from the pdb but the internal geometry of bomeba
* add "S" to the bomeba forcefield
* check that **all** implemented functions works properly with structures generated from a pdb (and add test)
